### PR TITLE
修复一个引号导致的Syntax Error

### DIFF
--- a/nonebot_plugin_bottle/__init__.py
+++ b/nonebot_plugin_bottle/__init__.py
@@ -55,7 +55,7 @@ SUPERUSER指令：
         "unique_name": "nonebot_plugin_bottle",
         "example": "扔漂流瓶\n寄漂流瓶\n捡漂流瓶\n评论漂流瓶\n举报漂流瓶\n查看漂流瓶\n删除漂流瓶",
         "author": "Todysheep",
-        "version": "0.2.7",
+        "version": "1.0.0",
     },
 )
 


### PR DESCRIPTION
GitHub这边没报错（是因为没更新），但是pypi那边的错了
修复报错：
```
File "/root/GZbot2/bot.py", line 26, in <module>
    nonebot.load_from_toml("pyproject.toml")
  File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/load.py", line 125, in load_from_toml
    return load_all_plugins(plugins, plugin_dirs)
  File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/load.py", line 62, in load_all_plugins
    return manager.load_all_plugins()
  File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 175, in load_all_plugins
    return set(
  File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 176, in <genexpr>
    filter(None, (self.load_plugin(name) for name in self.available_plugins))
> File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 141, in load_plugin
    module = importlib.import_module(name)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/usr/local/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 240, in exec_module
    super().exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/lib/python3.10/site-packages/nonebot_plugin_bottle/__init__.py", line 58
    "version": "1.0.0,
               ^
SyntaxError: unterminated string literal (detected at line 58)
```
![image](https://user-images.githubusercontent.com/65720409/235296625-fdb2c7be-6b04-4789-bf9b-6c466c015c89.png)
