### PR TITLE
Fix #71

### DIFF
--- a/nonebot_plugin_bottle/__init__.py
+++ b/nonebot_plugin_bottle/__init__.py
@@ -252,10 +252,14 @@ async def _(
     user_name = user_info.get("card") or user_info.get("nickname")
 
     try:
+        serialized_content = await serialize_message(message=args)
+        cache_result = [not part.get("data") for part in serialized_content if part["type"] == "cached_image"]
+        if any(cache_result):
+            await throw.finish(MessageSegment.reply(message_id) + "漂流瓶中的图片未能缓存成功。")
         add_index = await bottle_manager.add_bottle(
             user_id=event.user_id,
             group_id=event.group_id,
-            content=await serialize_message(message=args),
+            content=serialized_content,
             user_name=user_name,
             group_name=group_name,
             session=session,

--- a/nonebot_plugin_bottle/data_source.py
+++ b/nonebot_plugin_bottle/data_source.py
@@ -41,15 +41,19 @@ async def cache_file(msg: Message):
 
 
 async def cache_image_url(seg: MessageSegment, client: httpx.AsyncClient):
-    if url := seg.data.get("url"):
-        try:
-            r = await client.get(url)
-            data = r.content
-        except httpx.TimeoutException:
-            return
-        seg.type = "cached_image"
-        seg.data.clear()
-    else:
+    url = seg.data.get("url")
+    if not url:
+        return
+    
+    seg.type = "cached_image"
+    seg.data.clear()
+    try:
+        r = await client.get(url)
+        data = r.content
+    except httpx.TimeoutException:
+        return
+    
+    if r.status_code != 200 or not data:
         return
     hash = hashlib.md5(data).hexdigest()
     filename = f"{hash}.cache"


### PR DESCRIPTION
修改缓存函数 缓存失败时消息片段`data`为空
在生成瓶子判断片段是否有空`data`的`cached_image`对象判断瓶子图片是否正常缓存